### PR TITLE
Migrate from zsh to the objectively superior Fish shell.

### DIFF
--- a/.config/fish/conf.d/alias.fish
+++ b/.config/fish/conf.d/alias.fish
@@ -1,0 +1,64 @@
+# dotfiles: collection of my personal dotfiles
+# Copyright (C) 2012-2019 Aleksa Sarai <cyphar@cyphar.com>
+# Copyright (C) 2021 Chris Carter <chris@gibsonsec.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Some weird distros don't symlink vi -> vim (-> nvim). This is wrong. Also add
+# an alias for "v" just for my own sanity.
+alias v "vi"
+alias vi "vim"
+alias vim "nvim"
+
+# ls shortcuts and with colours.
+alias ls "ls --color=auto"
+alias sl "ls"
+alias ll "ls -alF"
+alias la "ls -A"
+alias l "ls -CF"
+
+# grep colours.
+alias grep "grep --color=auto"
+alias fgrep "fgrep --color=auto"
+alias egrep "egrep --color=auto"
+
+# Make Valgrind ... work.
+alias valgrind "valgrind --leak-check=full --trace-children=yes"
+alias vgs "valgrind --read-ver-info=yes"
+alias vg "valgrind"
+
+# NOTE: For `goc` and `prox/unprox` please see ~/.config/fish/functions/*.fish
+
+# Mess around with pico and nano.
+function nano
+	echo "Seriously? Why don't you just use notepad.exe, MS Paint or Emacs?"
+	return 1
+end
+
+alias pico "nano"
+
+# Add `time` to `make`, so that we get automagical build script timing
+# information, even if you forget to add `time`.
+abbr -a -g make "time make"
+
+# For OBS.
+alias iosc "osc -A https://api.suse.de"
+alias eosc "osc -A https://api.opensuse.org"
+
+# Nice^[citation needed] relative jumps.
+alias ..2 "cd ../.."
+alias ..3 "cd ../../.."
+alias ..4 "cd ../../../.."
+alias ..5 "cd ../../../../.."
+

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -1,0 +1,88 @@
+# dotfiles: collection of my personal dotfiles
+# Copyright (C) 2012-2019 Aleksa Sarai <cyphar@cyphar.com>
+# Copyright (C) 2021 Chris Carter <chris@gibsonsec.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Honestly I have no idea how Fish handles CJK. Let's gamble it's good.
+set -xg GTK_IM_MODULE ibus
+set -xg XMODIFIERS "@im=ibus"
+set -xg QT_IM_MODULE ibus
+
+# Only set up if running interactively
+if not status --is-interactive
+	exit 0
+end
+
+# If the current shell is not running in tmux, start/attach to a tmux session.
+if command -q tmux; and not set -q TMUX
+	# The default name for the tmux session is the superior `cyphar/fish`.
+	set -q TMUX_SESSION; or set -l TMUX_SESSION "cyphar/fish"
+
+	# Start the server in case it doesn't exist.
+	tmux start-server
+
+	if not tmux has-session -t "$TMUX_SESSION" ^/dev/null
+		tmux new-session -t "$TMUX_SESSION" -d -c "$HOME"
+	end
+
+	# Switch to tmux session.
+	# You can set $TMUX to any value to stop this from happening.
+	exec tmux attach-session -t "$TMUX_SESSION"
+end
+
+# Things not required because this isn't the 80s dammit, my shell has
+#   reasonable defaults:
+# - ~/.zsh/* -> Fish sources ~/.config/fish/conf.d/*.fish automatically
+# - `+histignoredups` and `+no_sharehistory` are... just reasonable defaults
+# - `+completealiases` - why is that optional?
+# - compinit -- auto complete is built in and colourful.
+# - ~/.profile ??? why separate bro
+# - `..` is a builtin as is `+autocd`
+# - I just ignored the entire `~/.zsh/input` file because I'm pretty sure any
+#   software made after Hackers (1995) has those as defaults...
+# Your prompt will forever be embedded in my nightmares.
+# All things considered ... probably don't set Fish to your login shell.
+
+if status --is-login
+	umask 022
+
+	add_to_path ~/.local/bin
+
+	set -xg EDITOR "nvim"
+	set -xg PAGER "less"
+	set -xg TERMINAL "alacritty"
+
+	# Make go ... work.
+	set -xg GOPATH "$HOME/go"
+	set -xg CDPATH . "$GOPATH/src"
+
+	# Make Python load `~/.pythonrc.py`
+	set -xg PYTHONSTARTUP "$HOME/.pythonrc.py"
+
+	# Made TERM work nicer. This is also changed by .tmux.conf, but we might as
+	# well ensure it's correct here.
+	set -xg TERM screen-256color
+
+	# Make sure "git commit" will actually show you pinentry...
+	set -xg GPG_TTY (tty)
+
+	if test -f ~/.cargo/env
+		source ~/.cargo/env
+	end
+
+	if command -q keychain
+		eval (keychain --eval --agents ssh -Q --quiet --nogui "$HOME/.ssh/id_ed25519")
+	end
+end

--- a/.config/fish/functions/add_to_path.fish
+++ b/.config/fish/functions/add_to_path.fish
@@ -1,0 +1,41 @@
+# Part of the "sysrq dotfiles experience". Available at:
+#    sysrq <chris@gibsonsec.org> https://github.com/sysr-q/dotfiles
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# For more information, please refer to <http://unlicense.org>
+
+function add_to_path -d "Add a directory to PATH if it exists"
+	if test (count $argv) = 0
+		return 1
+	end
+	for folder in $argv
+		if test ! -d $folder
+			continue
+		end
+		if not contains $folder $fish_user_paths
+			set --universal fish_user_paths $fish_user_paths $folder
+		end
+	end
+end

--- a/.config/fish/functions/fish_greeting.fish
+++ b/.config/fish/functions/fish_greeting.fish
@@ -1,0 +1,24 @@
+# dotfiles: collection of my personal dotfiles
+# Copyright (C) 2012-2019 Aleksa Sarai <cyphar@cyphar.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+function fish_greeting
+	if command -q figlet
+		figlet "<< "(uname -s)" >>"
+	end
+
+	# Father forgive me, for I have sinned.
+	echo (uname -o)" ("(uname -sr)") "(date)
+end

--- a/.config/fish/functions/fish_prompt.fish
+++ b/.config/fish/functions/fish_prompt.fish
@@ -1,0 +1,229 @@
+# dotfiles: collection of my personal dotfiles
+# Copyright (C) 2012-2019 Aleksa Sarai <cyphar@cyphar.com>
+# Copyright (C) 2021 Chris Carter <chris@gibsonsec.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+function __find_git -d "Search up the directory tree to find the '.git' folder" -a "current"
+	while test "$current" != "/"
+		if test -d "$current/.git"
+			echo "$current/.git"
+			return 0
+		end
+
+		set current (dirname -- "$current")
+	end
+
+	# Check for `/.git`
+	if test -d "$current/.git"
+		echo "$current/.git"
+		return 0
+	end
+
+	return 1
+end
+
+function __get_branch -d "Get the current branch ref from '.git/HEAD' and '.git/refs/heads'" -a "gitdir"
+	if grep -qv '^ref: refs/heads/.*$' -- "$gitdir/HEAD"
+		# Detached state -- no branch name.
+		return 1
+	end
+
+	# Get the ref path
+	set -l refbranch (cut -d' ' -f2 -- "$gitdir/HEAD")
+
+	# Yield the actual branch name from the refbranch.
+	echo (string replace -r '^refs/heads/' '' "$refbranch")
+	return 0
+end
+
+function __get_short_ref -d "Get short commit hash." -a "gitdir"
+	set -l refhash ""
+
+	# Deteached state -- ref is in 'ref'.
+	if not __get_branch "$gitdir" >/dev/null
+		set refhash (cat "$gitdir/HEAD")
+	else
+		# Get the ref path.
+		set -l refbranch (cut -d' ' -f2 -- "$gitdir/HEAD")
+
+		# Check that the refbranch exists
+		if not test -f "$gitdir/$refbranch"
+			# If not, we might be on a commit in a packed ref.
+			# Fallback to `git` in this case -- we can't do better.
+			set refhash (git rev-parse --verify HEAD)
+
+			# We don't have a commit.
+			if test $status -ne 0
+				return 1
+			end
+		else
+			# Get the commit hash from the ref path.
+			set refhash (cat "$gitdir/$refbranch")
+		end
+	end
+
+	# Shorten the ref to 12 characters. Why 12?
+	# Because that's what the kernel tell us is good.
+	# ~~ In Linus we trust. ~~
+	echo (string sub -e 12 "$refhash")
+	return 0
+end
+
+function __git_info -d "Git branch and ref information."
+	# Everything is calculated inside this shell script (no calls to `git` are
+	# made). This is because on large projects (like, say, the kernel) git can
+	# take >1 minute to figure out what branch and ref HEAD is pointing to. The
+	# filesystem is faster. However, we have to fall back in *one* case, when
+	# we are sitting on a packed ref or a repo which was recently gc'd -- in
+	# that case `git` is faster and easier.
+
+	# Most shells (Fish not included) like to be clever with symlinks. This
+	# breaks things like symlinks into subdirectories of git repositories
+	# (because `pwd` lies to you). Fish however doesn't need to be magical.
+	set -l real_pwd (pwd -P)
+
+	if __find_git "$real_pwd" >/dev/null ^/dev/null
+		set -l gitdir (__find_git "$real_pwd")
+
+		# Figure out if in detached state.
+		set -l refinfo
+		if __get_branch "$gitdir" >/dev/null
+			set refinfo (set_color -o magenta)(__get_branch "$gitdir")(set_color normal)
+		else
+			set refinfo (set_color -o red)'{detached}'(set_color normal)
+		end
+
+		# Figure out short ref.
+		set -l refhash
+		if __get_short_ref "$gitdir" >/dev/null
+			set refhash (set_color magenta)(__get_short_ref "$gitdir")(set_color normal)
+		else
+			set refhash (set_color magenta)000000000000(set_color normal)
+		end
+
+		echo " git:($refinfo:$refhash)"
+	end
+end
+
+function __find_hg -a "current"
+	# Hot path: check that there isn't a parent .hg/ directory.
+	# We don't implement parsing (I don't clone big hg project often enough to
+	# care).
+	while test "$current" != "/"
+		if test -d "$current/.hg"
+			echo "$current/.hg"
+			return 0
+		end
+
+		set current (dirname -- "$current")
+	end
+
+	# Check for `/.hg`
+	if test -d "$current/.hg"
+		echo "$current/.hg"
+		return 0
+	end
+
+	return 1
+end
+
+function __hg_info -d "Mercurial branch information."
+	# Most shells (Fish not included) like to be clever with symlinks. This
+	# breaks things like symlinks into subdirectories of Mercurial repositories
+	# (because `pwd` lies to you). Fish however doesn't need to be magical.
+	set -l real_pwd (pwd -P)
+
+	if __find_hg "$real_pwd" >/dev/null ^/dev/null; and hg status >/dev/null ^/dev/null
+		# TODO: Switch to reading (pwd)/.hg directly to avoid Python overhead.
+		set -l refbranch (hg branch)
+		set -l refhash (hg id | cut -d' ' -f1)
+
+		echo " hg:"(set_color -o magenta)"$refbranch"(set_color normal):(set_color magenta)"$refhash"(set_color normal)
+	end
+end
+
+function __nice_path -d "Get the last part of the given path, with tilde replacement." -a "current_path"
+	if test "$current_path" = "$HOME"
+		set current_path "~"
+	else
+		set current_path (basename "$current_path")
+	end
+
+	echo "$current_path"
+end
+
+function __ret_prompt -a "exit_code"
+	set -l prompt
+
+	# macOS compatibility
+	if not set -q EUID
+		set EUID (id -u)
+	end
+
+	if test "$EUID" -eq 0
+		set prompt "#"
+	else
+		set prompt "%"
+	end
+
+	if test "$exit_code" -ne 0
+		set prompt (set_color -o red)"$prompt"(set_color normal)
+	end
+
+	echo "$prompt "
+end
+
+function aleksa_fish_prompt
+	# Save old exit code first.
+	set -l exit_code $status
+
+	# Locals.
+	set -l user_prompt
+	set -l path_prompt
+	set -l ret_prompt
+
+	# macOS compatibility
+	if not set -q EUID
+		set EUID (id -u)
+	end
+
+	# User information
+	if test "$EUID" -eq 0
+		set user_prompt (set_color -o red)(hostname -f)(set_color normal)
+	else
+		set user_prompt (set_color -o green)"$USER"(set_color green)@(hostname -f)(set_color normal)
+	end
+
+	# Path information.
+	set path_prompt (printf "%s%s%s%s%s" (set_color -o blue) (__nice_path (pwd)) (set_color normal) (__git_info) (__hg_info))
+
+	# Return prompt based on exit code of last command.
+	set ret_prompt (__ret_prompt $exit_code)
+
+	# Actually set up prompts.
+	printf "%s %s::%s %s %s\n" "$user_prompt" (set_color cyan) (set_color normal) "$path_prompt" "$ret_prompt"
+end
+
+function aleksa_fish_right_prompt
+	function __loadavg
+		test -f "/proc/loadavg"; and echo (cat /proc/loadavg ^/dev/null | cut -d' ' -f1); or echo ""
+	end
+
+	function __nproc
+		echo (nproc ^/dev/null; or echo "?")
+	end
+
+	printf "[%s %s(%s)]" (uname -o) (__loadavg) (__nproc)
+end

--- a/.config/fish/functions/goc.fish
+++ b/.config/fish/functions/goc.fish
@@ -1,0 +1,27 @@
+# dotfiles: collection of my personal dotfiles
+# Copyright (C) 2012-2019 Aleksa Sarai <cyphar@cyphar.com>
+# Copyright (C) 2021 Chris Carter <chris@gibsonsec.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+function goc -d "Make cross-compiling Go easier" -a "arch"
+	echo env GOARCH="$arch" go $argv[2..-1]
+end
+
+# Behold! The miracles of abbreviations!
+# You can also use alias if you're feeling old school.
+abbr -a -g go64 "goc amd64"
+abbr -a -g go32 "goc 386"
+abbr -a -g goarm "goc arm"
+

--- a/.config/fish/functions/mutt.fish
+++ b/.config/fish/functions/mutt.fish
@@ -1,0 +1,26 @@
+# dotfiles: collection of my personal dotfiles
+# Copyright (C) 2012-2019 Aleksa Sarai <cyphar@cyphar.com>
+# Copyright (C) 2021 Chris Carter <chris@gibsonsec.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+function _mutt_wrapper -w "neomutt" -a "BOX"
+	mkdir -p "$HOME/mail/$BOX"
+	mbsync-helper -c "$HOME/.mbsyncrc-$BOX"; or true
+	neumutt -F "$HOME/.mutt/muttrc-$BOX" $argv[2..-1]
+	kill -9 (cat "$HOME/.mbsyncrc-$BOX.lock")
+end
+
+alias pmutt "_mutt_wrapper personal"
+alias smutt "_mutt_wrapper suse"

--- a/.config/fish/functions/proxies.fish
+++ b/.config/fish/functions/proxies.fish
@@ -1,0 +1,46 @@
+# dotfiles: collection of my personal dotfiles
+# Copyright (C) 2012-2019 Aleksa Sarai <cyphar@cyphar.com>
+# Copyright (C) 2021 Chris Carter <chris@gibsonsec.org>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+function prox -d "Make setting proxies simpler."
+	read -lP "username: " user
+	read -lsP "password: " pass
+
+	set -l server "$argv[1]"
+	set -l protocol "$argv[2]"
+	if test -z "$server"; read -P "server: " server; end
+	if test -z "$protocol"; read -P "protocol: " protocol; end
+
+	set -l proxy "$protocol://$user:$pass@$server"
+
+	set -xg HTTP_PROXY "$proxy"
+	set -xg HTTPS_PROXY "$proxy"
+	set -xg SOCKS_PROXY "$proxy"
+	set -xg FTP_PROXY "$proxy"
+	set -xg ALL_PROXY "$proxy"
+
+	set -xg http_proxy "$proxy"
+	set -xg https_proxy "$proxy"
+	set -xg socks_proxy "$proxy"
+	set -xg ftp_proxy "$proxy"
+	set -xg all_proxy "$proxy"
+end
+
+function unprox -d "Make deactivating proxies simpler."
+	set -e HTTP_PROXY HTTPS_PROXY SOCKS_PROXY FTP_PROXY ALL_PROXY
+	set -e http_proxy https_proxy socks_proxy ftp_proxy all_proxy
+end
+

--- a/install.py
+++ b/install.py
@@ -38,6 +38,7 @@ HOOK_AFTER = "after"
 OPTIONS = {
 	"bin":       (YES, [".local/bin/"]),
 	"dunst":     (YES, [".config/dunst/"]),
+	"fish":      (YES, [".config/fish/"]),
 	"fonts":     (YES, [".config/fontconfig/"]),
 	"git":       (YES, [".gitconfig"]),
 	"i3":        (YES, [".config/i3/", ".config/i3status/"]),


### PR DESCRIPTION
Hello Comrade Aleksa,

Given our recent discussion over who is or isn't using the better shell, I thought it would be worth my while to help you transition to the correct answer.
Fish is a wonderful tool, with many good defaults. Truly the best option available right now. This PR has been tested to the best of my abilities given my disposition to use macOS rather than GNU/Linus.

Things not required (but not forgotten) because this isn't the 80s dammit, my shell comes with reasonable defaults:

- `~/.zsh/*` -> Fish sources `~/.config/fish/conf.d/*.fish` automatically
- `+histignoredups` and `+no_sharehistory` are... just defaults
- `+completealiases` - why is that optional?
- `compinit` -- auto complete is built in and colourful.
- `~/.profile` - why is this separate from my bashrc or zshrc? Lame.
- `..` is a builtin as is `+autocd`
- I just ignored the entire `~/.zsh/input` file because I'm pretty sure any software made after Hackers (1995) has those as defaults...

All things considered ... probably don't set Fish to your login shell. Just make your terminal launch it.

P.S. Your prompt will forever be embedded in my nightmares.
P.P.S. Hopefully my use of the GPLv3 is fine here. Some of the code comes from my UNLICENSE dotfiles, but I'm happy to sublicense them to you under the GPLv3 (or greater) since they're handy. If this is wrong, please let me know. After all, I asked my friend the subject matter expert on the GPL but he might be wrong. ¯\_(ツ)_/¯
